### PR TITLE
Add reply for OPTIONS requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.o
 *.so
 nbproject/private/*
+.cproject

--- a/cWebServer.cpp
+++ b/cWebServer.cpp
@@ -102,6 +102,17 @@ int cWebServer::handle_connection (void *cls, struct MHD_Connection *connection,
     char *pass = NULL;
     bool fail;
 
+    if (0 == strcmp (method, MHD_HTTP_METHOD_OPTIONS)) {
+		const char *page = "OK";
+		response = MHD_create_response_from_buffer (strlen (page), (void *) page, MHD_RESPMEM_PERSISTENT);
+		MHD_add_response_header (response, "Allow", "GET");
+		MHD_add_response_header (response, "Access-Control-Allow-Origin", "*");
+		MHD_add_response_header (response, "Access-Control-Allow-Headers", "Authorization");
+		ret = MHD_queue_response (connection, MHD_HTTP_OK, response);
+		MHD_destroy_response (response);
+		return ret;
+    }
+
     if (0 != strcmp (method, MHD_HTTP_METHOD_GET)) {
         printf("No get. Method = %s\n", method);
         return MHD_NO;


### PR DESCRIPTION
Since XMLHttpRequest do a preflight request utilizing the OPTIONS method xmlapi must reply to them with status 200 and allow header for authenticated request to work.